### PR TITLE
Implement backend links on menu page

### DIFF
--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -106,6 +106,7 @@
       overflow: hidden;
       display: flex;
       flex-direction: column;
+      cursor: pointer;
     }
     .card img {
       width: 100%; height: 160px; object-fit: cover; background-color: #000;

--- a/public/js/menu/menu.js
+++ b/public/js/menu/menu.js
@@ -1,34 +1,72 @@
-    document.addEventListener('DOMContentLoaded', () => {
-      const el = document.getElementById('logo-text');
-      const logo = document.querySelector('.logo');
-      const base = 'Nerd Corner';
-      const alt = 'Cornerd';
-      let fromArr = [], toArr = [], i = 0, animating = false;
-      const randomDelay = () => 80 + Math.random() * 70;
+// public/js/menu/menu.js
+// Animation du logo
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('logo-text');
+  const logo = document.querySelector('.logo');
+  const base = 'Nerd Corner';
+  const alt  = 'Cornerd';
+  let fromArr = [], toArr = [], i = 0, animating = false;
+  const randomDelay = () => 80 + Math.random() * 70;
 
-      function erase() {
-        if (i < fromArr.length) {
-          el.textContent = fromArr.slice(0, fromArr.length - i - 1).join('');
-          i++; setTimeout(erase, randomDelay());
-        } else { i = 0; setTimeout(type, randomDelay() + 100); }
-      }
-      function type() {
-        if (i < toArr.length) {
-          el.textContent += toArr[i++];
-          setTimeout(type, randomDelay());
-        } else {
-          animating = false;
-          setTimeout(() => el.classList.add('finish'), 200);
-          setTimeout(() => el.classList.remove('typing','finish'), 200 + 3600 + 1000);
-        }
-      }
-      function startAnimation() {
-        if (animating) return;
-        animating = true; el.classList.add('typing');
-        const current = el.textContent;
-        if (current === base) { fromArr = base.split(''); toArr = alt.split(''); }
-        else { fromArr = alt.split(''); toArr = base.split(''); }
-        i = 0; erase();
-      }
-      logo.addEventListener('click', startAnimation);
-    });
+  function erase() {
+    if (i < fromArr.length) {
+      el.textContent = fromArr.slice(0, fromArr.length - i - 1).join('');
+      i++; setTimeout(erase, randomDelay());
+    } else { i = 0; setTimeout(type, randomDelay() + 100); }
+  }
+  function type() {
+    if (i < toArr.length) {
+      el.textContent += toArr[i++];
+      setTimeout(type, randomDelay());
+    } else {
+      animating = false;
+      setTimeout(() => el.classList.add('finish'), 200);
+      setTimeout(() => el.classList.remove('typing','finish'), 200 + 3600 + 1000);
+    }
+  }
+  function startAnimation() {
+    if (animating) return;
+    animating = true; el.classList.add('typing');
+    const current = el.textContent;
+    if (current === base) { fromArr = base.split(''); toArr = alt.split(''); }
+    else { fromArr = alt.split(''); toArr = base.split(''); }
+    i = 0; erase();
+  }
+  logo.addEventListener('click', startAnimation);
+});
+
+// Chargement des infos utilisateur et gestion des cartes
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const infoRes = await csrfFetch('/api/user/info');
+    if (infoRes.headers.get('Content-Type')?.includes('application/json')) {
+      const info = await infoRes.json();
+      document.getElementById('player-name').textContent = info.username;
+      document.getElementById('player-balance').textContent = info.balance;
+
+      const rankRes = await csrfFetch('/api/user/rank');
+      const { rank } = await rankRes.json();
+
+      const badgeRes = await csrfFetch('/api/badges');
+      const badges = await badgeRes.json();
+      const owned = [];
+      if (Number(badges.trader) === info.id) owned.push('Top Trader');
+      if (Number(badges.snake)  === info.id) owned.push('Top Snake');
+      if (Number(badges.pong)   === info.id) owned.push('Top Pong');
+
+      const infoEl = document.getElementById('player-info');
+      infoEl.innerHTML = `${owned.join(' ')}<br>Rank ${rank}`;
+    }
+  } catch (err) {
+    console.error('Menu init error:', err);
+  }
+
+  document.querySelectorAll('.card').forEach(card => {
+    const link = card.getAttribute('data-link');
+    if (link) {
+      card.addEventListener('click', () => {
+        window.location.href = link;
+      });
+    }
+  });
+});

--- a/public/menu.html
+++ b/public/menu.html
@@ -17,8 +17,8 @@
       <span id="logo-text" aria-live="polite">Nerd Corner</span>
     </div>
     <nav class="nav-links">
-      <a href="#">login</a>
-      <a href="#" class="sign-up">sign up</a>
+      <a href="/index.html">login</a>
+      <a href="/signup.html" class="sign-up">sign up</a>
       <select name="language" id="lang-select">
         <option value="fr">French</option>
         <option value="en">English</option>
@@ -27,20 +27,20 @@
   </header>
 
   <main>
-    <div class="title">Spectra</div>
-    <div class="value">5378</div>
-    <div class="subtitle">Top 1 Trader<br>Rank 5</div>
+    <div class="title" id="player-name">Guest</div>
+    <div class="value" id="player-balance">0</div>
+    <div class="subtitle" id="player-info"></div>
     <hr>
     <div class="cards">
-      <div class="card">
+      <div class="card" data-link="/snake.html">
         <img src="/assets/nerd.png" alt="Snake">
         <div class="label">Snake</div>
       </div>
-      <div class="card">
+      <div class="card" data-link="/dashboard.html">
         <img src="/assets/nerd.png" alt="Society Chart">
         <div class="label">Society</div>
       </div>
-      <div class="card">
+      <div class="card" data-link="/pong.html">
         <img src="/assets/nerd.png" alt="Gnop">
         <div class="label">Gnop</div>
       </div>


### PR DESCRIPTION
## Summary
- extend `/api/user/info` to expose username
- add `/api/user/rank` endpoint
- make menu page fetch user info, rank and badges
- link cards to pages and make them clickable
- minor style update for cards

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684827ebf5088328a7948eef40b96fad